### PR TITLE
Update cop param name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Style/TrailingCommaInHashLiteral:
 
 Metrics/BlockLength:
   Max: 35
-  ExcludedMethods: [ 'describe' ]
+  IgnoredMethods: [ 'describe' ]
 
 Metrics/MethodLength:
   Max: 25


### PR DESCRIPTION
```
obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`
```